### PR TITLE
got a 404 on that URL

### DIFF
--- a/dist/docs/substance/manual/content.json
+++ b/dist/docs/substance/manual/content.json
@@ -1104,7 +1104,7 @@
         216,
         229
       ],
-      "url": "https://github.com/substance/io/blob/master/docs/substance/manual/content.md"
+      "url": "https://github.com/substance/io/blob/master/dist/docs/substance/manual/content.md"
     },
     "emphasis_1": {
       "type": "emphasis",


### PR DESCRIPTION
when I clicked on the "You can contribute to this manual by making changes to the source markdown file." link in the manual, I got a 404. This URL is definitely broken. Now this is not a markdown file, so I am pretty sure this is not the most correct way of fixing this. But I could not find the md.
